### PR TITLE
Support TLS/SSL and the redis 6 ACL username

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -93,6 +93,7 @@ key: name, field:subject, value: name\01subject\01score.
 | host                  | (none)   | String  | Redis IP                                                                                                                                                                                           |
 | port                  | 6379     | Integer | Redis port                                                                                                                                                                                         |
 | password              | null     | String  | null if not set                                                                                                                                                                                    |
+| username              | (none)   | String  | Username for the redis ACL introduced in redis 6, only takes effect when password is also set                                                                                                      |
 | database              | 0        | Integer | db0 is used by default                                                                                                                                                                             |
 | timeout               | 2000     | Integer | Connection timeout, in ms, default 1s                                                                                                                                                              |
 | cluster-nodes         | (none)   | String  | Cluster ip and port, not empty when redis-mode is cluster, such as:10.11.80.147:7000,10.11.80.147:7001,10.11.80.147:8000                                                                           |
@@ -114,6 +115,8 @@ key: name, field:subject, value: name\01subject\01score.
 | scan.count            | (none)   | Integer | srandmember count                                                                                                                                                                                  |
 | zset.zremrangeby      | (none)   | String  | After executing zadd, whether to execute zremrangeby,Valid values are:SCORE、LEX、RANK                                                                                                               |
 | audit.log             | false    | Boolean | Turn on the audit log switch                                                                                                                                                                       |
+| ssl                   | false    | Boolean | Connect to redis over TLS/SSL                                                                                                                                                                      |
+| ssl.verify-peer       | true     | Boolean | Verify the peer certificate when ssl is enabled, set it to false to accept a self-signed certificate                                                                                               |
 
 
 ##### sink with ttl parameters
@@ -141,6 +144,38 @@ key: name, field:subject, value: name\01subject\01score.
 | master.name        | (none)  | String | master name |
 | sentinels.info     | (none)  | String |             |
 | sentinels.password | none)   | String |             |
+
+##### Connecting over TLS/SSL and with a redis ACL username:
+
+`ssl` and `username` work in single, cluster and sentinel mode. When `username` is set the
+connection authenticates with the redis 6 ACL form `AUTH username password`, otherwise the
+existing `AUTH password` behaviour is kept.
+
+```sql
+-- connect to a TLS enabled redis with ACL authentication
+create table sink_redis(name varchar, level varchar) with (
+    'connector'='redis',
+    'host'='10.11.80.147',
+    'port'='6379',
+    'redis-mode'='single',
+    'ssl'='true',
+    'username'='flink',
+    'password'='******',
+    'command'='set'
+);
+
+-- disable certificate verification when the server uses a self-signed certificate
+create table sink_redis(name varchar, level varchar) with (
+    'connector'='redis',
+    'host'='10.11.80.147',
+    'port'='6379',
+    'redis-mode'='single',
+    'ssl'='true',
+    'ssl.verify-peer'='false',
+    'password'='******',
+    'command'='set'
+);
+```
 
 ### Data Type Converter
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ on j.name = 'test'
 | host                  | (none) | String  | Redis IP                                                                                         |
 | port                  | 6379   | Integer | Redis 端口                                                                                         |
 | password              | null   | String  | 如果没有设置，则为 null                                                                                   |
+| username              | (none) | String  | redis 6 引入的 ACL 用户名，仅在同时设置了 password 时生效                                                         |
 | database              | 0      | Integer | 默认使用 db0                                                                                         |
 | timeout               | 2000   | Integer | 连接超时时间，单位 ms，默认 1s                                                                               |
 | cluster-nodes         | (none) | String  | 集群ip与端口，当redis-mode为cluster时不为空，如：10.11.80.147:7000,10.11.80.147:7001,10.11.80.147:8000          |
@@ -88,6 +89,8 @@ on j.name = 'test'
 | scan.count            | (none) | Integer | 查询set结构时指定srandmember count                                                                      |
 | zset.zremrangeby      | (none) | String  | 执行zadd之后，是否执行zremrangeby，取值：SCORE、LEX、RANK                                                       |
 | audit.log             | false  | Boolean | 打开sink日志                                                                                         |
+| ssl                   | false  | Boolean | 是否使用 TLS/SSL 连接 redis                                                                            |
+| ssl.verify-peer       | true   | Boolean | ssl 开启时是否校验对端证书，使用自签名证书时需设为 false                                                                |
 
 ### 3.1.1 command值与redis命令对应关系：
 
@@ -160,6 +163,37 @@ create table sink_redis(name VARCHAR, subject VARCHAR, score VARCHAR)  with ('co
 | master.name        | (none) | String | 主名                                                      |
 | sentinels.info     | (none) | String | 如：10.11.80.147:7000,10.11.80.147:7001,10.11.80.147:8000 |
 | sentinels.password | (none) | String | sentinel进程密码                                            |
+
+## 3.5 使用 TLS/SSL 与 redis ACL 用户名:
+
+`ssl` 与 `username` 在 single、cluster、sentinel 三种模式下均可使用。设置了 `username`
+时使用 redis 6 引入的 ACL 认证（`AUTH username password`），未设置时行为不变（`AUTH password`）。
+
+```sql
+-- 连接开启了 TLS 且启用了 ACL 的 redis
+create table sink_redis(name varchar, level varchar) with (
+    'connector'='redis',
+    'host'='10.11.80.147',
+    'port'='6379',
+    'redis-mode'='single',
+    'ssl'='true',
+    'username'='flink',
+    'password'='******',
+    'command'='set'
+);
+
+-- 服务端使用自签名证书时，关闭证书校验
+create table sink_redis(name varchar, level varchar) with (
+    'connector'='redis',
+    'host'='10.11.80.147',
+    'port'='6379',
+    'redis-mode'='single',
+    'ssl'='true',
+    'ssl.verify-peer'='false',
+    'password'='******',
+    'command'='set'
+);
+```
 
 # 4 数据类型转换
 

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkClusterConfig.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkClusterConfig.java
@@ -41,8 +41,14 @@ public class FlinkClusterConfig extends FlinkConfigBase {
      * @throws NullPointerException if parameter {@code nodes} is {@code null}
      */
     private FlinkClusterConfig(
-            String nodesInfo, int connectionTimeout, String password, LettuceConfig lettuceConfig) {
-        super(connectionTimeout, password, lettuceConfig);
+            String nodesInfo,
+            int connectionTimeout,
+            String username,
+            String password,
+            boolean ssl,
+            boolean sslVerifyPeer,
+            LettuceConfig lettuceConfig) {
+        super(connectionTimeout, username, password, ssl, sslVerifyPeer, lettuceConfig);
 
         Objects.requireNonNull(nodesInfo, "nodesInfo information should be presented");
         this.nodesInfo = nodesInfo;
@@ -53,7 +59,10 @@ public class FlinkClusterConfig extends FlinkConfigBase {
 
         private String nodesInfo;
         private int timeout;
+        private String username;
         private String password;
+        private boolean ssl;
+        private boolean sslVerifyPeer = true;
 
         private LettuceConfig lettuceConfig;
 
@@ -73,8 +82,35 @@ public class FlinkClusterConfig extends FlinkConfigBase {
             return this;
         }
 
+        public Builder setUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
         public Builder setPassword(String password) {
             this.password = password;
+            return this;
+        }
+
+        /**
+         * Sets whether to connect over TLS/SSL.
+         *
+         * @param ssl ssl, default value is false
+         * @return Builder itself
+         */
+        public Builder setSsl(boolean ssl) {
+            this.ssl = ssl;
+            return this;
+        }
+
+        /**
+         * Sets whether to verify the peer certificate, only meaningful when ssl is enabled.
+         *
+         * @param sslVerifyPeer sslVerifyPeer, default value is true
+         * @return Builder itself
+         */
+        public Builder setSslVerifyPeer(boolean sslVerifyPeer) {
+            this.sslVerifyPeer = sslVerifyPeer;
             return this;
         }
 
@@ -89,7 +125,8 @@ public class FlinkClusterConfig extends FlinkConfigBase {
          * @return ClusterConfig
          */
         public FlinkClusterConfig build() {
-            return new FlinkClusterConfig(nodesInfo, timeout, password, lettuceConfig);
+            return new FlinkClusterConfig(
+                    nodesInfo, timeout, username, password, ssl, sslVerifyPeer, lettuceConfig);
         }
     }
 }

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkClusterConfigHandler.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkClusterConfigHandler.java
@@ -45,7 +45,10 @@ public class FlinkClusterConfigHandler implements FlinkConfigHandler {
         FlinkClusterConfig.Builder builder =
                 new FlinkClusterConfig.Builder()
                         .setNodesInfo(nodesInfo)
+                        .setUsername(config.get(RedisOptions.USERNAME))
                         .setPassword(config.get(RedisOptions.PASSWORD))
+                        .setSsl(config.get(RedisOptions.SSL))
+                        .setSslVerifyPeer(config.get(RedisOptions.SSL_VERIFY_PEER))
                         .setLettuceConfig(lettuceConfig);
 
         builder.setTimeout(config.get(RedisOptions.TIMEOUT));

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkConfigBase.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkConfigBase.java
@@ -29,20 +29,58 @@ public abstract class FlinkConfigBase implements Serializable {
 
     protected final int connectionTimeout;
 
+    protected final String username;
+
     protected final String password;
+
+    protected final boolean ssl;
+
+    protected final boolean sslVerifyPeer;
 
     protected final LettuceConfig lettuceConfig;
 
-    protected FlinkConfigBase(int connectionTimeout, String password, LettuceConfig lettuceConfig) {
+    protected FlinkConfigBase(
+            int connectionTimeout,
+            String username,
+            String password,
+            boolean ssl,
+            boolean sslVerifyPeer,
+            LettuceConfig lettuceConfig) {
         Preconditions.checkArgument(
                 connectionTimeout >= 0, "connection timeout can not be negative");
+        this.username = username;
         this.password = password;
+        this.ssl = ssl;
+        this.sslVerifyPeer = sslVerifyPeer;
         this.connectionTimeout = connectionTimeout;
         this.lettuceConfig = lettuceConfig;
     }
 
+    public String getUsername() {
+        return username;
+    }
+
     public String getPassword() {
         return password;
+    }
+
+    /**
+     * Returns whether the connection is established over TLS/SSL.
+     *
+     * @return true if TLS/SSL is enabled
+     */
+    public boolean isSsl() {
+        return ssl;
+    }
+
+    /**
+     * Returns whether the peer certificate is verified when TLS/SSL is enabled. Only meaningful when
+     * {@link #isSsl()} returns true.
+     *
+     * @return true if the peer certificate is verified
+     */
+    public boolean isSslVerifyPeer() {
+        return sslVerifyPeer;
     }
 
     /**
@@ -63,9 +101,16 @@ public abstract class FlinkConfigBase implements Serializable {
         return "FlinkConfigBase{"
                 + "connectionTimeout="
                 + connectionTimeout
+                + ", username='"
+                + username
+                + '\''
                 + ", password='"
                 + password
                 + '\''
+                + ", ssl="
+                + ssl
+                + ", sslVerifyPeer="
+                + sslVerifyPeer
                 + ", lettuceConfig="
                 + lettuceConfig
                 + '}';

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkSentinelConfig.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkSentinelConfig.java
@@ -55,10 +55,13 @@ public class FlinkSentinelConfig extends FlinkConfigBase {
             int connectionTimeout,
             int soTimeout,
             int database,
+            String username,
             String password,
             String sentinelsPassword,
+            boolean ssl,
+            boolean sslVerifyPeer,
             LettuceConfig lettuceConfig) {
-        super(connectionTimeout, password, lettuceConfig);
+        super(connectionTimeout, username, password, ssl, sslVerifyPeer, lettuceConfig);
         Objects.requireNonNull(masterName, "Master name should be presented");
         Objects.requireNonNull(sentinelsInfo, "Sentinels information should be presented");
         this.masterName = masterName;
@@ -111,8 +114,11 @@ public class FlinkSentinelConfig extends FlinkConfigBase {
         private int connectionTimeout;
         private int soTimeout;
         private int database;
+        private String username;
         private String password;
         private String sentinelsPassword;
+        private boolean ssl;
+        private boolean sslVerifyPeer = true;
 
         private LettuceConfig lettuceConfig;
 
@@ -165,6 +171,11 @@ public class FlinkSentinelConfig extends FlinkConfigBase {
             return this;
         }
 
+        public Builder setUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
         public Builder setPassword(String password) {
             this.password = password;
             return this;
@@ -172,6 +183,28 @@ public class FlinkSentinelConfig extends FlinkConfigBase {
 
         public Builder setSentinelsPassword(String sentinelsPassword) {
             this.sentinelsPassword = sentinelsPassword;
+            return this;
+        }
+
+        /**
+         * Sets whether to connect over TLS/SSL.
+         *
+         * @param ssl ssl, default value is false
+         * @return Builder itself
+         */
+        public Builder setSsl(boolean ssl) {
+            this.ssl = ssl;
+            return this;
+        }
+
+        /**
+         * Sets whether to verify the peer certificate, only meaningful when ssl is enabled.
+         *
+         * @param sslVerifyPeer sslVerifyPeer, default value is true
+         * @return Builder itself
+         */
+        public Builder setSslVerifyPeer(boolean sslVerifyPeer) {
+            this.sslVerifyPeer = sslVerifyPeer;
             return this;
         }
 
@@ -192,8 +225,11 @@ public class FlinkSentinelConfig extends FlinkConfigBase {
                     connectionTimeout,
                     soTimeout,
                     database,
+                    username,
                     password,
                     sentinelsPassword,
+                    ssl,
+                    sslVerifyPeer,
                     lettuceConfig);
         }
     }

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkSentinelConfigHandler.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkSentinelConfigHandler.java
@@ -53,8 +53,11 @@ public class FlinkSentinelConfigHandler implements FlinkConfigHandler {
                         .setMasterName(masterName)
                         .setConnectionTimeout(config.get(RedisOptions.TIMEOUT))
                         .setDatabase(config.get(RedisOptions.DATABASE))
+                        .setUsername(config.get(RedisOptions.USERNAME))
                         .setPassword(config.get(RedisOptions.PASSWORD))
                         .setSentinelsPassword(sentinelsPassword)
+                        .setSsl(config.get(RedisOptions.SSL))
+                        .setSslVerifyPeer(config.get(RedisOptions.SSL_VERIFY_PEER))
                         .setLettuceConfig(lettuceConfig)
                         .build();
         return flinkSentinelConfig;

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkSingleConfig.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkSingleConfig.java
@@ -43,10 +43,13 @@ public class FlinkSingleConfig extends FlinkConfigBase {
             String host,
             int port,
             int connectionTimeout,
+            String username,
             String password,
             int database,
+            boolean ssl,
+            boolean sslVerifyPeer,
             LettuceConfig lettuceConfig) {
-        super(connectionTimeout, password, lettuceConfig);
+        super(connectionTimeout, username, password, ssl, sslVerifyPeer, lettuceConfig);
         Objects.requireNonNull(host, "Host information should be presented");
         this.host = host;
         this.port = port;
@@ -87,7 +90,10 @@ public class FlinkSingleConfig extends FlinkConfigBase {
         private int port;
         private int timeout;
         private int database;
+        private String username;
         private String password;
+        private boolean ssl;
+        private boolean sslVerifyPeer = true;
 
         private LettuceConfig lettuceConfig;
 
@@ -136,6 +142,17 @@ public class FlinkSingleConfig extends FlinkConfigBase {
         }
 
         /**
+         * Sets username.
+         *
+         * @param username username, if any
+         * @return Builder itself
+         */
+        public Builder setUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
+        /**
          * Sets password.
          *
          * @param password password, if any
@@ -143,6 +160,28 @@ public class FlinkSingleConfig extends FlinkConfigBase {
          */
         public Builder setPassword(String password) {
             this.password = password;
+            return this;
+        }
+
+        /**
+         * Sets whether to connect over TLS/SSL.
+         *
+         * @param ssl ssl, default value is false
+         * @return Builder itself
+         */
+        public Builder setSsl(boolean ssl) {
+            this.ssl = ssl;
+            return this;
+        }
+
+        /**
+         * Sets whether to verify the peer certificate, only meaningful when ssl is enabled.
+         *
+         * @param sslVerifyPeer sslVerifyPeer, default value is true
+         * @return Builder itself
+         */
+        public Builder setSslVerifyPeer(boolean sslVerifyPeer) {
+            this.sslVerifyPeer = sslVerifyPeer;
             return this;
         }
 
@@ -157,7 +196,16 @@ public class FlinkSingleConfig extends FlinkConfigBase {
          * @return PoolConfig
          */
         public FlinkSingleConfig build() {
-            return new FlinkSingleConfig(host, port, timeout, password, database, lettuceConfig);
+            return new FlinkSingleConfig(
+                    host,
+                    port,
+                    timeout,
+                    username,
+                    password,
+                    database,
+                    ssl,
+                    sslVerifyPeer,
+                    lettuceConfig);
         }
     }
 }

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkSingleConfigHandler.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/FlinkSingleConfigHandler.java
@@ -40,7 +40,10 @@ public class FlinkSingleConfigHandler implements FlinkConfigHandler {
         FlinkSingleConfig.Builder builder =
                 new FlinkSingleConfig.Builder()
                         .setHost(host)
+                        .setUsername(config.get(RedisOptions.USERNAME))
                         .setPassword(config.get(RedisOptions.PASSWORD))
+                        .setSsl(config.get(RedisOptions.SSL))
+                        .setSslVerifyPeer(config.get(RedisOptions.SSL_VERIFY_PEER))
                         .setLettuceConfig(lettuceConfig);
         builder.setPort(config.get(RedisOptions.PORT));
         builder.setTimeout(config.get(RedisOptions.TIMEOUT))

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/RedisOptions.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/RedisOptions.java
@@ -211,5 +211,6 @@ public class RedisOptions {
                     .defaultValue(false)
                     .withDescription("Optional turn on the audit log switch.");
 
-    private RedisOptions() {}
+    private RedisOptions() {
+    }
 }

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/RedisOptions.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/RedisOptions.java
@@ -44,6 +44,13 @@ public class RedisOptions {
                     .intType()
                     .defaultValue(1)
                     .withDescription("Optional minIdle for connect to redis");
+    public static final ConfigOption<String> USERNAME =
+            ConfigOptions.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional username for connect to redis, only takes effect together with"
+                                    + " password, used by the redis ACL introduced in redis 6.");
     public static final ConfigOption<String> PASSWORD =
             ConfigOptions.key("password")
                     .stringType()
@@ -210,6 +217,18 @@ public class RedisOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Optional turn on the audit log switch.");
+    public static final ConfigOption<Boolean> SSL =
+            ConfigOptions.key("ssl")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Optional connect to redis over TLS/SSL.");
+    public static final ConfigOption<Boolean> SSL_VERIFY_PEER =
+            ConfigOptions.key("ssl.verify-peer")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Optional verify the peer certificate when ssl is enabled, set it to"
+                                    + " false to accept self-signed certificates.");
 
     private RedisOptions() {
     }

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilder.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilder.java
@@ -18,6 +18,12 @@
 
 package org.apache.flink.streaming.connectors.redis.container;
 
+import org.apache.flink.streaming.connectors.redis.config.FlinkClusterConfig;
+import org.apache.flink.streaming.connectors.redis.config.FlinkConfigBase;
+import org.apache.flink.streaming.connectors.redis.config.FlinkSentinelConfig;
+import org.apache.flink.streaming.connectors.redis.config.FlinkSingleConfig;
+import org.apache.flink.util.StringUtils;
+
 import io.lettuce.core.AbstractRedisClient;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
@@ -26,12 +32,6 @@ import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.core.resource.DefaultClientResources;
-
-import org.apache.flink.streaming.connectors.redis.config.FlinkClusterConfig;
-import org.apache.flink.streaming.connectors.redis.config.FlinkConfigBase;
-import org.apache.flink.streaming.connectors.redis.config.FlinkSentinelConfig;
-import org.apache.flink.streaming.connectors.redis.config.FlinkSingleConfig;
-import org.apache.flink.util.StringUtils;
 
 import java.time.Duration;
 import java.util.Arrays;

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilder.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.redis.container;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.streaming.connectors.redis.config.FlinkClusterConfig;
 import org.apache.flink.streaming.connectors.redis.config.FlinkConfigBase;
 import org.apache.flink.streaming.connectors.redis.config.FlinkSentinelConfig;
@@ -87,8 +88,8 @@ public class RedisClientBuilder {
      * @param builder uri builder to configure
      * @param config configuration holding the credentials and the ssl settings
      */
-    private static void applyAuthenticationAndSsl(
-            RedisURI.Builder builder, FlinkConfigBase config) {
+    @VisibleForTesting
+    static void applyAuthenticationAndSsl(RedisURI.Builder builder, FlinkConfigBase config) {
         if (!StringUtils.isNullOrWhitespaceOnly(config.getPassword())) {
             if (StringUtils.isNullOrWhitespaceOnly(config.getUsername())) {
                 builder.withPassword(config.getPassword().toCharArray());

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilder.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilder.java
@@ -78,6 +78,32 @@ public class RedisClientBuilder {
     }
 
     /**
+     * Applies the authentication and the TLS/SSL settings shared by all the redis modes to the given
+     * uri builder.
+     *
+     * <p>When a username is configured the redis ACL command {@code AUTH username password}
+     * introduced in redis 6 is used, otherwise the connection falls back to {@code AUTH password}.
+     *
+     * @param builder uri builder to configure
+     * @param config configuration holding the credentials and the ssl settings
+     */
+    private static void applyAuthenticationAndSsl(
+            RedisURI.Builder builder, FlinkConfigBase config) {
+        if (!StringUtils.isNullOrWhitespaceOnly(config.getPassword())) {
+            if (StringUtils.isNullOrWhitespaceOnly(config.getUsername())) {
+                builder.withPassword(config.getPassword().toCharArray());
+            } else {
+                builder.withAuthentication(
+                        config.getUsername(), config.getPassword().toCharArray());
+            }
+        }
+
+        if (config.isSsl()) {
+            builder.withSsl(true).withVerifyPeer(config.isSslVerifyPeer());
+        }
+    }
+
+    /**
      * Builds container for single Redis environment.
      *
      * @param singleConfig configuration for redis
@@ -93,9 +119,7 @@ public class RedisClientBuilder {
                         .withHost(singleConfig.getHost())
                         .withPort(singleConfig.getPort())
                         .withDatabase(singleConfig.getDatabase());
-        if (!StringUtils.isNullOrWhitespaceOnly(singleConfig.getPassword())) {
-            builder.withPassword(singleConfig.getPassword().toCharArray());
-        }
+        applyAuthenticationAndSsl(builder, singleConfig);
 
         return RedisClient.create(clientResources, builder.build());
     }
@@ -120,11 +144,7 @@ public class RedisClientBuilder {
                                             RedisURI.builder()
                                                     .withHost(redis[0])
                                                     .withPort(Integer.parseInt(redis[1]));
-                                    if (!StringUtils.isNullOrWhitespaceOnly(
-                                            clusterConfig.getPassword())) {
-                                        builder.withPassword(
-                                                clusterConfig.getPassword().toCharArray());
-                                    }
+                                    applyAuthenticationAndSsl(builder, clusterConfig);
                                     return builder.build();
                                 })
                         .collect(Collectors.toList());
@@ -165,19 +185,13 @@ public class RedisClientBuilder {
                 .forEach(
                         node -> {
                             String[] redis = node.split(":");
-                            if (StringUtils.isNullOrWhitespaceOnly(sentinelConfig.getPassword())) {
-                                builder.withSentinel(
-                                        redis[0],
-                                        Integer.parseInt(redis[1]),
-                                        sentinelConfig.getSentinelsPassword());
-                            } else {
-                                builder.withSentinel(
-                                        redis[0],
-                                        Integer.parseInt(redis[1]),
-                                        sentinelConfig.getSentinelsPassword())
-                                        .withPassword(sentinelConfig.getPassword().toCharArray());
-                            }
+                            builder.withSentinel(
+                                    redis[0],
+                                    Integer.parseInt(redis[1]),
+                                    sentinelConfig.getSentinelsPassword());
                         });
+
+        applyAuthenticationAndSsl(builder, sentinelConfig);
 
         return RedisClient.create(clientResources, builder.build());
     }

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClusterContainer.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClusterContainer.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.streaming.connectors.redis.container;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.lettuce.core.Range;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.time.Duration;

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisContainer.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisContainer.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.streaming.connectors.redis.container;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.lettuce.core.Range;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.List;

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisDynamicTableFactory.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisDynamicTableFactory.java
@@ -118,6 +118,9 @@ public class RedisDynamicTableFactory
         options.add(RedisOptions.SCAN_COUNT);
         options.add(RedisOptions.ZREM_RANGEBY);
         options.add(RedisOptions.AUDIT_LOG);
+        options.add(RedisOptions.USERNAME);
+        options.add(RedisOptions.SSL);
+        options.add(RedisOptions.SSL_VERIFY_PEER);
         return options;
     }
 

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisSinkFunction.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisSinkFunction.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.streaming.connectors.redis.table;
 
-import io.lettuce.core.Range;
-import io.lettuce.core.RedisFuture;
-
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
@@ -42,6 +39,9 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.lettuce.core.Range;
+import io.lettuce.core.RedisFuture;
 
 import java.io.IOException;
 import java.time.LocalTime;
@@ -192,20 +192,19 @@ public class RedisSinkFunction<IN> extends RichSinkFunction<IN> {
             case SADD:
                 redisFuture = this.redisCommandsContainer.sadd(params[0], params[1]);
                 break;
-            case SET:
-                {
-                    if (!this.setIfAbsent) {
-                        redisFuture = this.redisCommandsContainer.set(params[0], params[1]);
-                    } else {
-                        redisFuture = this.redisCommandsContainer.exists(params[0]);
-                        redisFuture.whenComplete(
-                                (existsVal, throwable) -> {
-                                    if ((int) existsVal == 0) {
-                                        this.redisCommandsContainer.set(params[0], params[1]);
-                                    }
-                                });
-                    }
+            case SET: {
+                if (!this.setIfAbsent) {
+                    redisFuture = this.redisCommandsContainer.set(params[0], params[1]);
+                } else {
+                    redisFuture = this.redisCommandsContainer.exists(params[0]);
+                    redisFuture.whenComplete(
+                            (existsVal, throwable) -> {
+                                if ((int) existsVal == 0) {
+                                    this.redisCommandsContainer.set(params[0], params[1]);
+                                }
+                            });
                 }
+            }
                 break;
             case PFADD:
                 redisFuture = this.redisCommandsContainer.pfadd(params[0], params[1]);
@@ -257,48 +256,46 @@ public class RedisSinkFunction<IN> extends RichSinkFunction<IN> {
             case SREM:
                 redisFuture = this.redisCommandsContainer.srem(params[0], params[1]);
                 break;
-            case HSET:
-                {
-                    if (!this.setIfAbsent) {
-                        redisFuture =
-                                this.redisCommandsContainer.hset(params[0], params[1], params[2]);
-                    } else {
-                        redisFuture = this.redisCommandsContainer.hexists(params[0], params[1]);
-                        redisFuture.whenComplete(
-                                (exist, throwable) -> {
-                                    if (!(Boolean) exist) {
-                                        this.redisCommandsContainer.hset(
-                                                params[0], params[1], params[2]);
-                                    }
-                                });
-                    }
+            case HSET: {
+                if (!this.setIfAbsent) {
+                    redisFuture =
+                            this.redisCommandsContainer.hset(params[0], params[1], params[2]);
+                } else {
+                    redisFuture = this.redisCommandsContainer.hexists(params[0], params[1]);
+                    redisFuture.whenComplete(
+                            (exist, throwable) -> {
+                                if (!(Boolean) exist) {
+                                    this.redisCommandsContainer.hset(
+                                            params[0], params[1], params[2]);
+                                }
+                            });
                 }
+            }
                 break;
-            case HMSET:
-                {
-                    if (params.length < 2) {
-                        throw new RuntimeException("params length must be greater than 2");
-                    }
-                    if (params.length % 2 != 1) {
-                        throw new RuntimeException("params length must be odd");
-                    }
-                    // 遍历把params第一个下标作为key，从第二个下标作为value，存进map中
-                    Map<String, String> hashField = new HashMap<>();
-                    for (int i = 1; i < params.length; i++) {
-                        hashField.put(params[i], params[++i]);
-                    }
-                    if (!this.setIfAbsent) {
-                        redisFuture = this.redisCommandsContainer.hmset(params[0], hashField);
-                    } else {
-                        redisFuture = this.redisCommandsContainer.exists(params[0]);
-                        redisFuture.whenComplete(
-                                (exist, throwable) -> {
-                                    if (!(Boolean) exist) {
-                                        this.redisCommandsContainer.hmset(params[0], hashField);
-                                    }
-                                });
-                    }
+            case HMSET: {
+                if (params.length < 2) {
+                    throw new RuntimeException("params length must be greater than 2");
                 }
+                if (params.length % 2 != 1) {
+                    throw new RuntimeException("params length must be odd");
+                }
+                // 遍历把params第一个下标作为key，从第二个下标作为value，存进map中
+                Map<String, String> hashField = new HashMap<>();
+                for (int i = 1; i < params.length; i++) {
+                    hashField.put(params[i], params[++i]);
+                }
+                if (!this.setIfAbsent) {
+                    redisFuture = this.redisCommandsContainer.hmset(params[0], hashField);
+                } else {
+                    redisFuture = this.redisCommandsContainer.exists(params[0]);
+                    redisFuture.whenComplete(
+                            (exist, throwable) -> {
+                                if (!(Boolean) exist) {
+                                    this.redisCommandsContainer.hmset(params[0], hashField);
+                                }
+                            });
+                }
+            }
                 break;
             case HINCRBY:
                 redisFuture =
@@ -357,10 +354,9 @@ public class RedisSinkFunction<IN> extends RichSinkFunction<IN> {
                 Double d = -Double.valueOf(params[1]);
                 redisFuture = this.redisCommandsContainer.zincrBy(params[0], d, params[2]);
                 break;
-            case HDEL:
-                {
-                    redisFuture = this.redisCommandsContainer.hdel(params[0], params[1]);
-                }
+            case HDEL: {
+                redisFuture = this.redisCommandsContainer.hdel(params[0], params[1]);
+            }
                 break;
             case HINCRBY:
                 redisFuture =

--- a/src/test/java/org/apache/flink/streaming/connectors/redis/config/RedisSslConfigHandlerTest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/redis/config/RedisSslConfigHandlerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.redis.config;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.redis.table.RedisDynamicTableFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that username, ssl and ssl.verify-peer reach the {@link FlinkConfigBase} of every redis
+ * mode. Does not require a running redis instance.
+ */
+public class RedisSslConfigHandlerTest {
+
+    private static Configuration singleOptions() {
+        Configuration configuration = new Configuration();
+        configuration.setString(RedisOptions.HOST.key(), "localhost");
+        return configuration;
+    }
+
+    private static Configuration clusterOptions() {
+        Configuration configuration = new Configuration();
+        configuration.setString(RedisOptions.CLUSTERNODES.key(), "localhost:7000,localhost:7001");
+        return configuration;
+    }
+
+    private static Configuration sentinelOptions() {
+        Configuration configuration = new Configuration();
+        configuration.setString(RedisOptions.REDIS_MASTER_NAME.key(), "master");
+        configuration.setString(RedisOptions.SENTINELS_INFO.key(), "localhost:26379");
+        return configuration;
+    }
+
+    private static void withSslOptions(Configuration configuration) {
+        configuration.setString(RedisOptions.USERNAME.key(), "flink");
+        configuration.setString(RedisOptions.PASSWORD.key(), "pwd");
+        configuration.setString(RedisOptions.SSL.key(), "true");
+        configuration.setString(RedisOptions.SSL_VERIFY_PEER.key(), "false");
+    }
+
+    private static void assertSslOptionsApplied(FlinkConfigBase config) {
+        assertEquals("flink", config.getUsername());
+        assertEquals("pwd", config.getPassword());
+        assertTrue(config.isSsl());
+        assertFalse(config.isSslVerifyPeer());
+    }
+
+    private static void assertDefaults(FlinkConfigBase config) {
+        assertNull(config.getUsername());
+        assertFalse(config.isSsl());
+        assertTrue(config.isSslVerifyPeer());
+    }
+
+    @Test
+    public void testSingleConfigHandler() {
+        Configuration configuration = singleOptions();
+        withSslOptions(configuration);
+
+        assertSslOptionsApplied(new FlinkSingleConfigHandler().createFlinkConfig(configuration));
+    }
+
+    @Test
+    public void testClusterConfigHandler() {
+        Configuration configuration = clusterOptions();
+        withSslOptions(configuration);
+
+        assertSslOptionsApplied(new FlinkClusterConfigHandler().createFlinkConfig(configuration));
+    }
+
+    @Test
+    public void testSentinelConfigHandler() {
+        Configuration configuration = sentinelOptions();
+        withSslOptions(configuration);
+
+        assertSslOptionsApplied(new FlinkSentinelConfigHandler().createFlinkConfig(configuration));
+    }
+
+    @Test
+    public void testDefaultsAreBackwardsCompatible() {
+        assertDefaults(new FlinkSingleConfigHandler().createFlinkConfig(singleOptions()));
+        assertDefaults(new FlinkClusterConfigHandler().createFlinkConfig(clusterOptions()));
+        assertDefaults(new FlinkSentinelConfigHandler().createFlinkConfig(sentinelOptions()));
+    }
+
+    @Test
+    public void testOptionsAreDeclaredByTheFactory() {
+        assertTrue(
+                new RedisDynamicTableFactory()
+                        .optionalOptions()
+                        .containsAll(
+                                Arrays.asList(
+                                        RedisOptions.USERNAME,
+                                        RedisOptions.SSL,
+                                        RedisOptions.SSL_VERIFY_PEER)));
+    }
+}

--- a/src/test/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilderSslTest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilderSslTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.redis.container;
+
+import org.apache.flink.streaming.connectors.redis.config.FlinkSingleConfig;
+import org.junit.jupiter.api.Test;
+
+import io.lettuce.core.RedisURI;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that the authentication and the TLS/SSL settings end up on the {@link RedisURI} handed to
+ * lettuce. Does not require a running redis instance.
+ */
+public class RedisClientBuilderSslTest {
+
+    private static RedisURI uriFor(FlinkSingleConfig config) {
+        RedisURI.Builder builder = RedisURI.builder().withHost("localhost").withPort(6379);
+        RedisClientBuilder.applyAuthenticationAndSsl(builder, config);
+        return builder.build();
+    }
+
+    private static FlinkSingleConfig.Builder configBuilder() {
+        return new FlinkSingleConfig.Builder().setHost("localhost").setPort(6379);
+    }
+
+    @Test
+    public void testPasswordOnlyKeepsUsernameUnset() {
+        RedisURI uri = uriFor(configBuilder().setPassword("pwd").build());
+
+        assertNull(uri.getUsername());
+        assertArrayEquals("pwd".toCharArray(), uri.getPassword());
+        assertFalse(uri.isSsl());
+    }
+
+    @Test
+    public void testUsernameAndPasswordUseAclAuthentication() {
+        RedisURI uri = uriFor(configBuilder().setUsername("flink").setPassword("pwd").build());
+
+        assertEquals("flink", uri.getUsername());
+        assertArrayEquals("pwd".toCharArray(), uri.getPassword());
+    }
+
+    @Test
+    public void testUsernameWithoutPasswordIsIgnored() {
+        RedisURI uri = uriFor(configBuilder().setUsername("flink").build());
+
+        assertNull(uri.getUsername());
+        assertNull(uri.getPassword());
+    }
+
+    @Test
+    public void testBlankPasswordDoesNotAuthenticate() {
+        RedisURI uri = uriFor(configBuilder().setUsername("flink").setPassword("  ").build());
+
+        assertNull(uri.getUsername());
+        assertNull(uri.getPassword());
+    }
+
+    @Test
+    public void testSslDisabledByDefault() {
+        RedisURI uri = uriFor(configBuilder().build());
+
+        assertFalse(uri.isSsl());
+    }
+
+    @Test
+    public void testSslVerifiesPeerByDefault() {
+        RedisURI uri = uriFor(configBuilder().setSsl(true).build());
+
+        assertTrue(uri.isSsl());
+        assertTrue(uri.isVerifyPeer());
+    }
+
+    @Test
+    public void testSslVerifyPeerCanBeDisabled() {
+        RedisURI uri = uriFor(configBuilder().setSsl(true).setSslVerifyPeer(false).build());
+
+        assertTrue(uri.isSsl());
+        assertFalse(uri.isVerifyPeer());
+    }
+
+    @Test
+    public void testSslVerifyPeerIsIgnoredWhenSslIsDisabled() {
+        RedisURI uri = uriFor(configBuilder().setSsl(false).setSslVerifyPeer(false).build());
+
+        assertFalse(uri.isSsl());
+        assertTrue(uri.isVerifyPeer());
+    }
+}

--- a/src/test/java/org/apache/flink/streaming/connectors/redis/table/SQLInsertTest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/redis/table/SQLInsertTest.java
@@ -18,10 +18,6 @@
 
 package org.apache.flink.streaming.connectors.redis.table;
 
-import static org.apache.flink.streaming.connectors.redis.config.RedisValidator.REDIS_COMMAND;
-
-import io.lettuce.core.Range;
-
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.redis.command.RedisCommand;
 import org.apache.flink.streaming.connectors.redis.table.base.TestRedisConfigBase;
@@ -30,6 +26,10 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.Preconditions;
+
+import io.lettuce.core.Range;
+
+import static org.apache.flink.streaming.connectors.redis.config.RedisValidator.REDIS_COMMAND;
 
 /** Created by jeff.zou on 2020/9/10. */
 public class SQLInsertTest extends TestRedisConfigBase {


### PR DESCRIPTION
Closes #58.

## What

Adds three optional connector options so the connector can talk to a TLS-enabled
Redis and to a Redis 6 instance that uses ACL users. They work in `single`,
`cluster` and `sentinel` mode.

| Option | Default | Type | Description |
|---|---|---|---|
| `username` | (none) | String | Redis ACL username, only takes effect when `password` is also set |
| `ssl` | `false` | Boolean | Connect over TLS/SSL |
| `ssl.verify-peer` | `true` | Boolean | Verify the peer certificate when `ssl` is enabled |

```sql
create table sink_redis(name varchar, level varchar) with (
    'connector'='redis',
    'host'='10.11.80.147',
    'port'='6379',
    'redis-mode'='single',
    'ssl'='true',
    'username'='flink',
    'password'='******',
    'command'='set'
);
```

## Why

Managed Redis offerings (AWS ElastiCache in-transit encryption, Azure Cache for
Redis, Alibaba Cloud Tair, …) require TLS, and Redis 6 ACL users are the normal
way to give a Flink job a least-privilege account. Neither was reachable through
the connector before — `RedisClientBuilder` only ever called
`RedisURI.Builder#withPassword`.

## Notes for the reviewer

**The first commit is a build fix, please read it first.** `spotless:check` is
bound to the `compile` phase, so `mvn clean package` — and therefore both the
*Build Connector* and *Code Style Checker* workflows — currently fails on `dev`
at `93d0d93`, on six files:

```
src/main/java/.../config/RedisOptions.java
src/main/java/.../container/RedisContainer.java
src/main/java/.../container/RedisClusterContainer.java
src/main/java/.../container/RedisClientBuilder.java
src/main/java/.../table/RedisSinkFunction.java
src/test/java/.../table/SQLInsertTest.java
```

`29a793d` is the verbatim output of `mvn spotless:apply` with no manual edits
(the `org` import group has to precede the catch-all group, and `RedisOptions`
had an over-long line). Four of those files are unrelated to this feature and
are touched only by that commit — happy to split it into its own PR and rebase
if you would rather keep them separate.

Beyond that:

- **`ssl.verify-peer` defaults to `true`**, matching Lettuce's own `RedisURI`
  default, so enabling `ssl` alone stays secure. Set it to `false` for a
  self-signed certificate.
- **Backwards compatible.** With no new option set, the generated `RedisURI` is
  byte-for-byte what it was before: `ssl` off, and `AUTH password` (not
  `AUTH username password`) whenever a username is absent. Covered by
  `testDefaultsAreBackwardsCompatible`.
- Authentication and SSL are applied through one shared helper
  (`applyAuthenticationAndSsl`) so the three modes cannot drift apart.
- **Drive-by fix in the sentinel path:** `withPassword` was being called inside
  the per-node `forEach`, i.e. re-applied once per sentinel node, and the two
  `if`/`else` branches differed only by that call. It is now applied once,
  outside the loop. Same resulting URI, less repetition.
- **Tests do not need a running Redis.** Every existing test extends
  `TestRedisConfigBase` and needs a reachable server, so the two new classes are
  standalone and safe to run in CI. `applyAuthenticationAndSsl` is package
  private + `@VisibleForTesting` so the built `RedisURI` can be asserted on
  without opening a connection.
- Docs added to the option tables in both `README.md` and `README-en.md`, plus a
  short DDL example section.

## Testing

```
mvn clean package -DskipTests                        # BUILD SUCCESS (incl. spotless:check)
mvn test -Dtest='RedisClientBuilderSslTest,RedisSslConfigHandlerTest'
# Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
```

The pre-existing test suites were not run, as they require a Redis at the
hardcoded `10.11.69.176`.

