### PR TITLE
Fix NoClassDefFoundError on the lookup cache by dropping the shaded calcite guava

### DIFF
--- a/src/main/java/org/apache/flink/streaming/connectors/redis/config/RedisOptions.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/config/RedisOptions.java
@@ -211,5 +211,6 @@ public class RedisOptions {
                     .defaultValue(false)
                     .withDescription("Optional turn on the audit log switch.");
 
-    private RedisOptions() {}
+    private RedisOptions() {
+    }
 }

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilder.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClientBuilder.java
@@ -18,6 +18,12 @@
 
 package org.apache.flink.streaming.connectors.redis.container;
 
+import org.apache.flink.streaming.connectors.redis.config.FlinkClusterConfig;
+import org.apache.flink.streaming.connectors.redis.config.FlinkConfigBase;
+import org.apache.flink.streaming.connectors.redis.config.FlinkSentinelConfig;
+import org.apache.flink.streaming.connectors.redis.config.FlinkSingleConfig;
+import org.apache.flink.util.StringUtils;
+
 import io.lettuce.core.AbstractRedisClient;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
@@ -26,12 +32,6 @@ import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.resource.ClientResources;
 import io.lettuce.core.resource.DefaultClientResources;
-
-import org.apache.flink.streaming.connectors.redis.config.FlinkClusterConfig;
-import org.apache.flink.streaming.connectors.redis.config.FlinkConfigBase;
-import org.apache.flink.streaming.connectors.redis.config.FlinkSentinelConfig;
-import org.apache.flink.streaming.connectors.redis.config.FlinkSingleConfig;
-import org.apache.flink.util.StringUtils;
 
 import java.time.Duration;
 import java.util.Arrays;

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClusterContainer.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisClusterContainer.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.streaming.connectors.redis.container;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.lettuce.core.Range;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.async.RedisAdvancedClusterAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.time.Duration;

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisContainer.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/container/RedisContainer.java
@@ -18,15 +18,15 @@
 
 package org.apache.flink.streaming.connectors.redis.container;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.lettuce.core.Range;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisFuture;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.async.RedisAsyncCommands;
 import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.List;

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisLookupCache.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisLookupCache.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.redis.table;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.Preconditions;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+/**
+ * Bounded cache with expire-after-write semantics, used by {@link RedisLookupFunction} to hold
+ * looked up rows.
+ *
+ * <p>This replaces the guava cache that used to be imported from {@code
+ * org.apache.flink.calcite.shaded.com.google.common.cache}. That package is an internal shading
+ * artifact of flink-table-planner rather than public api, and since flink 1.15 the planner sits
+ * behind flink-table-planner-loader and its isolated class loader, so it cannot be loaded from user
+ * code at all. Implementing the two methods the lookup function actually needs avoids both the
+ * broken dependency and adding a guava of our own to the connector jar.
+ *
+ * <p>Entries expire once {@code ttlSeconds} have passed since they were written, matching guava's
+ * {@code expireAfterWrite}. Once {@code maximumSize} is exceeded the least recently used entry is
+ * evicted, matching guava's {@code maximumSize}. Reading an entry does not extend its lifetime.
+ *
+ * <p>All methods are thread safe: {@link #getIfPresent} is called from the task thread inside {@code
+ * eval}, while {@link #put} is called from lettuce's netty event loop threads when a {@code
+ * RedisFuture} completes.
+ */
+public class RedisLookupCache {
+
+    private final long ttlNanos;
+
+    private final LongSupplier nanoClock;
+
+    private final LinkedHashMap<String, CacheEntry> entries;
+
+    public RedisLookupCache(long ttlSeconds, long maximumSize) {
+        this(ttlSeconds, maximumSize, System::nanoTime);
+    }
+
+    @VisibleForTesting
+    RedisLookupCache(long ttlSeconds, long maximumSize, LongSupplier nanoClock) {
+        Preconditions.checkArgument(ttlSeconds >= 0, "cache ttl can not be negative");
+        Preconditions.checkArgument(maximumSize >= 0, "cache maximum size can not be negative");
+        this.ttlNanos = TimeUnit.SECONDS.toNanos(ttlSeconds);
+        this.nanoClock = nanoClock;
+        // access ordered so that removeEldestEntry evicts the least recently used entry
+        this.entries =
+                new LinkedHashMap<String, CacheEntry>(16, 0.75f, true) {
+
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    protected boolean removeEldestEntry(Map.Entry<String, CacheEntry> eldest) {
+                        return size() > maximumSize;
+                    }
+                };
+    }
+
+    /**
+     * Returns the value cached under the given key, or null when it was never cached or has expired.
+     *
+     * @param key cache key
+     * @return the cached value, or null
+     */
+    public synchronized Object getIfPresent(String key) {
+        CacheEntry entry = entries.get(key);
+        if (entry == null) {
+            return null;
+        }
+
+        if (nanoClock.getAsLong() - entry.writeNanos >= ttlNanos) {
+            entries.remove(key);
+            return null;
+        }
+
+        return entry.value;
+    }
+
+    /**
+     * Caches the value under the given key, restarting its time to live.
+     *
+     * @param key cache key
+     * @param value value to cache
+     */
+    public synchronized void put(String key, Object value) {
+        entries.put(key, new CacheEntry(value, nanoClock.getAsLong()));
+    }
+
+    /** Drops every entry, releasing the cached rows on close. */
+    public synchronized void clear() {
+        entries.clear();
+    }
+
+    /**
+     * Returns the number of entries held, including any that have expired but have not been read
+     * again since.
+     *
+     * @return number of entries held
+     */
+    @VisibleForTesting
+    synchronized int size() {
+        return entries.size();
+    }
+
+    private static final class CacheEntry {
+
+        private final Object value;
+
+        private final long writeNanos;
+
+        private CacheEntry(Object value, long writeNanos) {
+            this.value = value;
+            this.writeNanos = writeNanos;
+        }
+    }
+}

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisLookupFunction.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisLookupFunction.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.streaming.connectors.redis.table;
 
-import org.apache.flink.calcite.shaded.com.google.common.cache.Cache;
-import org.apache.flink.calcite.shaded.com.google.common.cache.CacheBuilder;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.connectors.redis.command.RedisCommand;
 import org.apache.flink.streaming.connectors.redis.command.RedisCommandBaseDescription;
@@ -48,7 +46,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.streaming.connectors.redis.table.RedisDynamicTableFactory.CACHE_SEPERATOR;
 
@@ -67,7 +64,7 @@ public class RedisLookupFunction extends AsyncTableFunction<RowData> {
     private final List<DataType> dataTypes;
     private final boolean loadAll;
     private final RedisValueDataStructure redisValueDataStructure;
-    private Cache<String, Object> cache;
+    private transient RedisLookupCache cache;
 
     public RedisLookupFunction(
             FlinkConfigBase flinkConfigBase,
@@ -298,10 +295,7 @@ public class RedisLookupFunction extends AsyncTableFunction<RowData> {
         this.cache =
                 cacheMaxSize == -1 || cacheTtl == -1
                         ? null
-                        : CacheBuilder.newBuilder()
-                                .expireAfterWrite(cacheTtl, TimeUnit.SECONDS)
-                                .maximumSize(cacheMaxSize)
-                                .build();
+                        : new RedisLookupCache(cacheTtl, cacheMaxSize);
     }
 
     @Override
@@ -311,7 +305,7 @@ public class RedisLookupFunction extends AsyncTableFunction<RowData> {
         }
 
         if (cache != null) {
-            cache.cleanUp();
+            cache.clear();
             cache = null;
         }
     }

--- a/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisSinkFunction.java
+++ b/src/main/java/org/apache/flink/streaming/connectors/redis/table/RedisSinkFunction.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.streaming.connectors.redis.table;
 
-import io.lettuce.core.Range;
-import io.lettuce.core.RedisFuture;
-
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
@@ -42,6 +39,9 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.lettuce.core.Range;
+import io.lettuce.core.RedisFuture;
 
 import java.io.IOException;
 import java.time.LocalTime;
@@ -192,20 +192,19 @@ public class RedisSinkFunction<IN> extends RichSinkFunction<IN> {
             case SADD:
                 redisFuture = this.redisCommandsContainer.sadd(params[0], params[1]);
                 break;
-            case SET:
-                {
-                    if (!this.setIfAbsent) {
-                        redisFuture = this.redisCommandsContainer.set(params[0], params[1]);
-                    } else {
-                        redisFuture = this.redisCommandsContainer.exists(params[0]);
-                        redisFuture.whenComplete(
-                                (existsVal, throwable) -> {
-                                    if ((int) existsVal == 0) {
-                                        this.redisCommandsContainer.set(params[0], params[1]);
-                                    }
-                                });
-                    }
+            case SET: {
+                if (!this.setIfAbsent) {
+                    redisFuture = this.redisCommandsContainer.set(params[0], params[1]);
+                } else {
+                    redisFuture = this.redisCommandsContainer.exists(params[0]);
+                    redisFuture.whenComplete(
+                            (existsVal, throwable) -> {
+                                if ((int) existsVal == 0) {
+                                    this.redisCommandsContainer.set(params[0], params[1]);
+                                }
+                            });
                 }
+            }
                 break;
             case PFADD:
                 redisFuture = this.redisCommandsContainer.pfadd(params[0], params[1]);
@@ -257,48 +256,46 @@ public class RedisSinkFunction<IN> extends RichSinkFunction<IN> {
             case SREM:
                 redisFuture = this.redisCommandsContainer.srem(params[0], params[1]);
                 break;
-            case HSET:
-                {
-                    if (!this.setIfAbsent) {
-                        redisFuture =
-                                this.redisCommandsContainer.hset(params[0], params[1], params[2]);
-                    } else {
-                        redisFuture = this.redisCommandsContainer.hexists(params[0], params[1]);
-                        redisFuture.whenComplete(
-                                (exist, throwable) -> {
-                                    if (!(Boolean) exist) {
-                                        this.redisCommandsContainer.hset(
-                                                params[0], params[1], params[2]);
-                                    }
-                                });
-                    }
+            case HSET: {
+                if (!this.setIfAbsent) {
+                    redisFuture =
+                            this.redisCommandsContainer.hset(params[0], params[1], params[2]);
+                } else {
+                    redisFuture = this.redisCommandsContainer.hexists(params[0], params[1]);
+                    redisFuture.whenComplete(
+                            (exist, throwable) -> {
+                                if (!(Boolean) exist) {
+                                    this.redisCommandsContainer.hset(
+                                            params[0], params[1], params[2]);
+                                }
+                            });
                 }
+            }
                 break;
-            case HMSET:
-                {
-                    if (params.length < 2) {
-                        throw new RuntimeException("params length must be greater than 2");
-                    }
-                    if (params.length % 2 != 1) {
-                        throw new RuntimeException("params length must be odd");
-                    }
-                    // 遍历把params第一个下标作为key，从第二个下标作为value，存进map中
-                    Map<String, String> hashField = new HashMap<>();
-                    for (int i = 1; i < params.length; i++) {
-                        hashField.put(params[i], params[++i]);
-                    }
-                    if (!this.setIfAbsent) {
-                        redisFuture = this.redisCommandsContainer.hmset(params[0], hashField);
-                    } else {
-                        redisFuture = this.redisCommandsContainer.exists(params[0]);
-                        redisFuture.whenComplete(
-                                (exist, throwable) -> {
-                                    if (!(Boolean) exist) {
-                                        this.redisCommandsContainer.hmset(params[0], hashField);
-                                    }
-                                });
-                    }
+            case HMSET: {
+                if (params.length < 2) {
+                    throw new RuntimeException("params length must be greater than 2");
                 }
+                if (params.length % 2 != 1) {
+                    throw new RuntimeException("params length must be odd");
+                }
+                // 遍历把params第一个下标作为key，从第二个下标作为value，存进map中
+                Map<String, String> hashField = new HashMap<>();
+                for (int i = 1; i < params.length; i++) {
+                    hashField.put(params[i], params[++i]);
+                }
+                if (!this.setIfAbsent) {
+                    redisFuture = this.redisCommandsContainer.hmset(params[0], hashField);
+                } else {
+                    redisFuture = this.redisCommandsContainer.exists(params[0]);
+                    redisFuture.whenComplete(
+                            (exist, throwable) -> {
+                                if (!(Boolean) exist) {
+                                    this.redisCommandsContainer.hmset(params[0], hashField);
+                                }
+                            });
+                }
+            }
                 break;
             case HINCRBY:
                 redisFuture =
@@ -357,10 +354,9 @@ public class RedisSinkFunction<IN> extends RichSinkFunction<IN> {
                 Double d = -Double.valueOf(params[1]);
                 redisFuture = this.redisCommandsContainer.zincrBy(params[0], d, params[2]);
                 break;
-            case HDEL:
-                {
-                    redisFuture = this.redisCommandsContainer.hdel(params[0], params[1]);
-                }
+            case HDEL: {
+                redisFuture = this.redisCommandsContainer.hdel(params[0], params[1]);
+            }
                 break;
             case HINCRBY:
                 redisFuture =

--- a/src/test/java/org/apache/flink/streaming/connectors/redis/table/RedisLookupCacheTest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/redis/table/RedisLookupCacheTest.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.redis.table;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link RedisLookupCache}, the replacement for the guava cache that used to come from the
+ * shaded calcite inside flink-table-planner. Time is injected, so no test sleeps.
+ */
+public class RedisLookupCacheTest {
+
+    /** Manually advanced nano clock, so expiry can be tested without sleeping. */
+    private static final class FakeClock {
+
+        private final AtomicLong nanos = new AtomicLong();
+
+        private long get() {
+            return nanos.get();
+        }
+
+        private void advanceSeconds(long seconds) {
+            nanos.addAndGet(TimeUnit.SECONDS.toNanos(seconds));
+        }
+    }
+
+    @Test
+    public void testPutThenGet() {
+        RedisLookupCache cache = new RedisLookupCache(10, 100);
+
+        cache.put("k", "v");
+
+        assertEquals("v", cache.getIfPresent("k"));
+    }
+
+    @Test
+    public void testMissReturnsNull() {
+        RedisLookupCache cache = new RedisLookupCache(10, 100);
+
+        assertNull(cache.getIfPresent("absent"));
+    }
+
+    @Test
+    public void testEntryExpiresAfterTtl() {
+        FakeClock clock = new FakeClock();
+        RedisLookupCache cache = new RedisLookupCache(10, 100, clock::get);
+
+        cache.put("k", "v");
+        clock.advanceSeconds(9);
+        assertEquals("v", cache.getIfPresent("k"), "must still be cached just before the ttl");
+
+        clock.advanceSeconds(1);
+        assertNull(cache.getIfPresent("k"), "must be gone once the ttl has elapsed");
+    }
+
+    @Test
+    public void testReadDoesNotExtendTtl() {
+        FakeClock clock = new FakeClock();
+        RedisLookupCache cache = new RedisLookupCache(10, 100, clock::get);
+
+        cache.put("k", "v");
+        // read repeatedly across the whole window; expireAfterWrite must not be refreshed by a read
+        for (int i = 0; i < 9; i++) {
+            clock.advanceSeconds(1);
+            assertEquals("v", cache.getIfPresent("k"));
+        }
+
+        clock.advanceSeconds(1);
+        assertNull(cache.getIfPresent("k"), "ttl is counted from the write, not from the last read");
+    }
+
+    @Test
+    public void testRewriteRestartsTtl() {
+        FakeClock clock = new FakeClock();
+        RedisLookupCache cache = new RedisLookupCache(10, 100, clock::get);
+
+        cache.put("k", "v1");
+        clock.advanceSeconds(9);
+        cache.put("k", "v2");
+        clock.advanceSeconds(9);
+
+        assertEquals("v2", cache.getIfPresent("k"));
+    }
+
+    @Test
+    public void testExpiredEntryIsRemovedNotJustHidden() {
+        FakeClock clock = new FakeClock();
+        RedisLookupCache cache = new RedisLookupCache(10, 100, clock::get);
+
+        cache.put("k", "v");
+        clock.advanceSeconds(10);
+
+        assertEquals(1, cache.size());
+        assertNull(cache.getIfPresent("k"));
+        assertEquals(0, cache.size(), "reading an expired entry must drop it");
+    }
+
+    @Test
+    public void testSizeIsBounded() {
+        RedisLookupCache cache = new RedisLookupCache(10, 3);
+
+        for (int i = 0; i < 100; i++) {
+            cache.put("k" + i, "v" + i);
+        }
+
+        assertEquals(3, cache.size());
+    }
+
+    @Test
+    public void testLeastRecentlyUsedEntryIsEvicted() {
+        RedisLookupCache cache = new RedisLookupCache(10, 2);
+
+        cache.put("a", "va");
+        cache.put("b", "vb");
+        // touching "a" makes "b" the least recently used one
+        assertEquals("va", cache.getIfPresent("a"));
+        cache.put("c", "vc");
+
+        assertEquals("va", cache.getIfPresent("a"));
+        assertEquals("vc", cache.getIfPresent("c"));
+        assertNull(cache.getIfPresent("b"), "the least recently used entry must be evicted");
+    }
+
+    @Test
+    public void testZeroMaximumSizeCachesNothing() {
+        RedisLookupCache cache = new RedisLookupCache(10, 0);
+
+        cache.put("k", "v");
+
+        assertNull(cache.getIfPresent("k"));
+        assertEquals(0, cache.size());
+    }
+
+    @Test
+    public void testZeroTtlExpiresImmediately() {
+        RedisLookupCache cache = new RedisLookupCache(0, 100);
+
+        cache.put("k", "v");
+
+        assertNull(cache.getIfPresent("k"));
+    }
+
+    @Test
+    public void testClearDropsEverything() {
+        RedisLookupCache cache = new RedisLookupCache(10, 100);
+        cache.put("a", "va");
+        cache.put("b", "vb");
+
+        cache.clear();
+
+        assertEquals(0, cache.size());
+        assertNull(cache.getIfPresent("a"));
+    }
+
+    @Test
+    public void testNegativeArgumentsAreRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new RedisLookupCache(-1, 100));
+        assertThrows(IllegalArgumentException.class, () -> new RedisLookupCache(10, -1));
+    }
+
+    /**
+     * getIfPresent runs on the task thread while put runs on lettuce's netty event loop threads, so
+     * the cache has to survive concurrent access the way the guava cache did.
+     */
+    @Test
+    public void testConcurrentPutAndGet() throws Exception {
+        RedisLookupCache cache = new RedisLookupCache(60, 64);
+        int threads = 8;
+        int iterations = 5_000;
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        List<Future<?>> futures = new ArrayList<>();
+
+        try {
+            for (int t = 0; t < threads; t++) {
+                final int id = t;
+                futures.add(
+                        pool.submit(
+                                () -> {
+                                    try {
+                                        start.await();
+                                        for (int i = 0; i < iterations; i++) {
+                                            String key = "k" + ((id * iterations + i) % 128);
+                                            cache.put(key, "v" + i);
+                                            cache.getIfPresent(key);
+                                        }
+                                    } catch (Throwable e) {
+                                        failure.compareAndSet(null, e);
+                                    }
+                                }));
+            }
+
+            start.countDown();
+            for (Future<?> future : futures) {
+                future.get(60, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertNull(failure.get(), "concurrent access must not throw");
+        assertTrue(cache.size() <= 64, "the size bound must hold under concurrency");
+    }
+}

--- a/src/test/java/org/apache/flink/streaming/connectors/redis/table/SQLInsertTest.java
+++ b/src/test/java/org/apache/flink/streaming/connectors/redis/table/SQLInsertTest.java
@@ -18,10 +18,6 @@
 
 package org.apache.flink.streaming.connectors.redis.table;
 
-import static org.apache.flink.streaming.connectors.redis.config.RedisValidator.REDIS_COMMAND;
-
-import io.lettuce.core.Range;
-
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.redis.command.RedisCommand;
 import org.apache.flink.streaming.connectors.redis.table.base.TestRedisConfigBase;
@@ -30,6 +26,10 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.Preconditions;
+
+import io.lettuce.core.Range;
+
+import static org.apache.flink.streaming.connectors.redis.config.RedisValidator.REDIS_COMMAND;
 
 /** Created by jeff.zou on 2020/9/10. */
 public class SQLInsertTest extends TestRedisConfigBase {


### PR DESCRIPTION
Closes #69.

## What

`RedisLookupFunction` took its lookup cache from
`org.apache.flink.calcite.shaded.com.google.common.cache`, an internal shading
artifact of `flink-table-planner`. Since Flink 1.15 the planner sits behind
`flink-table-planner-loader` and its isolated `ComponentClassLoader`, so that
package is not reachable from user code and the job dies with
`NoClassDefFoundError` as soon as the lookup cache is enabled. Full analysis and
a standalone reproduction are in #69.

This replaces it with `RedisLookupCache` — no new dependency, and nothing that
has to track which guava a given Flink release happens to shade.

## The replacement

Only what the lookup function actually used is implemented (`getIfPresent`,
`put`, and a `clear` for `close`), backed by an access-ordered `LinkedHashMap`:

| guava behaviour | kept? |
|---|---|
| `expireAfterWrite`, counted from the write, not refreshed by a read | yes |
| `maximumSize` with least-recently-used eviction | yes |
| thread safe | yes — `synchronized` |
| `maximumSize(0)` caches nothing, `expireAfterWrite(0)` expires at once | yes |

**Thread safety is not optional here.** All four `cache.put` call sites are
inside `RedisFuture.thenAccept(...)`, i.e. they run on Lettuce's netty event
loop threads, while `cache.getIfPresent` runs on the task thread inside `eval`.
The guava cache provided that, so the replacement has to as well.

Two small things came along with it:

- The `cache` field is now `transient`. It has always been created in `open()`,
  and the guava `Cache` was never serialized either.
- `close()` called guava's `cleanUp()` on the line before dropping the
  reference, which was a no-op. It now calls `clear()`, which is what was
  intended.

## Verification

**1. The built jar no longer references the shaded package at all** — across all
58 classes in the connector jar:

```console
$ find . -name '*.class' -exec javap -c -p {} + | grep -cE 'calcite/shaded|com/google/common'
0
```

**2. It now runs on the classpath that used to fail.** Same setup as the
reproduction in #69 — Flink 1.15.1, `flink-table-planner-loader` on the
classpath and no planner jar, which is the standard Flink 1.15+ layout:

```console
$ java -cp ".:$CONN:$CORE:$ANNO:$LOADER" CacheReproFixed
cache created: org.apache.flink.streaming.connectors.redis.table.RedisLookupCache
getIfPresent(k) = v
getIfPresent(absent) = null
```

Before this change, the equivalent program on that exact classpath threw
`NoClassDefFoundError: org/apache/flink/calcite/shaded/com/google/common/cache/CacheBuilder`.

**3. Tests.** 13 unit tests, no redis instance and no sleeps — the nano clock is
injected through a package-private constructor, so expiry is deterministic:

```console
$ mvn clean package -DskipTests     # BUILD SUCCESS (incl. spotless:check)
$ mvn test -Dtest=RedisLookupCacheTest
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
```

They were mutation-checked rather than just run — flipping the expiry boundary
from `>=` to `>` fails 3 tests, and degrading the LRU to FIFO (access-order
`true` → `false`) fails `testLeastRecentlyUsedEntryIsEvicted`.

The pre-existing test suites were not run; they all extend `TestRedisConfigBase`
and need a reachable redis at the hardcoded `10.11.69.176`.

## Note on the first commit

`049fe67` is a build fix, not part of this change — `spotless:check` is bound to
the `compile` phase and currently fails on `main` on six files, so `mvn clean
package` cannot succeed without it. It is the verbatim output of `mvn
spotless:apply`, and it is byte-identical to the first commit of #68; whichever
of the two lands first, it drops out of the other on rebase. Happy to pull it
out into its own PR if you would rather review it separately.
